### PR TITLE
Normalize PROM template payloads

### DIFF
--- a/apps/clinic-dashboard/src/services/promApi.ts
+++ b/apps/clinic-dashboard/src/services/promApi.ts
@@ -1,31 +1,59 @@
 import apiClient from './sharedApiClient';
 import { PromInstanceDto } from './promInstanceApi';
 
-export interface PromTemplate {
-  id: string;
-  name: string;
-  description: string;
-  questions: PromQuestion[];
-  estimatedTime?: string;
-  tags?: string[];
-  category?: string;
-  isActive: boolean;
-  version: number;
-  createdAt: string;
-  updatedAt: string;
-}
-
 export interface PromQuestion {
   id: string;
   text: string;
-  type: 'text' | 'number' | 'scale' | 'multiple-choice' | 'checkbox' | 'date' | 'time';
+  type:
+    | 'text'
+    | 'number'
+    | 'scale'
+    | 'multiple-choice'
+    | 'checkbox'
+    | 'date'
+    | 'time'
+    | 'radio';
   required: boolean;
   options?: string[];
   min?: number;
   max?: number;
   step?: number;
-  placeholder?: string;
-  validation?: any;
+  description?: string;
+  conditionalLogic?: Record<string, unknown>;
+  scoring?: Record<string, unknown>;
+}
+
+export interface PromTemplateSummary {
+  id: string;
+  key: string;
+  version: number;
+  name: string;
+  description?: string;
+  category: string;
+  frequency: string;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PromTemplateDetail extends PromTemplateSummary {
+  questions: PromQuestion[];
+  scoringMethod?: Record<string, unknown>;
+  scoringRules?: Record<string, unknown>;
+  isActive: boolean;
+}
+
+export interface CreatePromTemplateRequest {
+  key: string;
+  name: string;
+  description?: string;
+  category: string;
+  frequency: string;
+  questions: PromQuestion[];
+  scoringMethod?: Record<string, unknown>;
+  scoringRules?: Record<string, unknown>;
+  isActive?: boolean;
+  version?: number;
 }
 
 export interface PromResponse {
@@ -48,31 +76,22 @@ class PromApi {
     search?: string;
     page?: number;
     limit?: number;
-  }) {
+  }): Promise<PromTemplateSummary[]> {
     const response = await apiClient.get('/api/v1/proms/templates', { params });
     return response.data;
   }
 
-  async getTemplate(id: string) {
+  async getTemplate(id: string): Promise<PromTemplateDetail> {
     const response = await apiClient.get(`/api/v1/proms/templates/by-id/${id}`);
     return response.data;
   }
 
-  async createTemplate(data: {
-    key: string;
-    name: string;
-    description?: string;
-    schemaJson: string;
-    scoringMethod?: string;
-    scoringRules?: string;
-    isActive?: boolean;
-    version?: number;
-  }) {
+  async createTemplate(data: CreatePromTemplateRequest): Promise<PromTemplateDetail> {
     const response = await apiClient.post('/api/v1/proms/templates', data);
     return response.data;
   }
 
-  async updateTemplate(id: string, data: Partial<PromTemplate>) {
+  async updateTemplate(id: string, data: Partial<PromTemplateDetail>) {
     const response = await apiClient.put(`/api/v1/proms/templates/by-id/${id}`, data);
     return response.data;
   }
@@ -157,7 +176,7 @@ class PromApi {
   }
 
   async submitResponse(id: string, responses: Record<string, any>) {
-    const response = await apiClient.post(`/api/v1/proms/instances/${id}/answers`, { responses });
+    const response = await apiClient.post(`/api/v1/proms/instances/${id}/answers`, responses);
     return response.data;
   }
 

--- a/apps/clinic-dashboard/src/services/proms.ts
+++ b/apps/clinic-dashboard/src/services/proms.ts
@@ -1,24 +1,9 @@
 import apiClient from './sharedApiClient';
-
-export interface CreatePromTemplatePayload {
-	key: string;
-	name: string;
-	description?: string;
-	schemaJson: string; // stringified JSON from builder
-	scoringMethod?: string;
-	scoringRules?: string; // stringified JSON
-	isActive?: boolean;
-	version?: number;
-}
-
-export interface PromTemplateSummary {
-	id: string;
-	key: string;
-	version: number;
-	name: string;
-	description?: string;
-	createdAt: string;
-}
+import type {
+        CreatePromTemplateRequest,
+        PromTemplateDetail,
+        PromTemplateSummary,
+} from './promApi';
 
 export interface SchedulePromPayload {
 	templateKey: string;
@@ -29,29 +14,29 @@ export interface SchedulePromPayload {
 }
 
 export const promsApi = {
-	createTemplate: async (payload: CreatePromTemplatePayload) => {
-		const res = await apiClient.post('/api/v1/proms/templates', payload);
-		return res.data as { id: string; key: string; version: number };
-	},
-	getTemplate: async (key: string, version?: number) => {
-		const path = version ? `/api/v1/proms/templates/${key}/${version}` : `/api/v1/proms/templates/${key}`;
-		const res = await apiClient.get(path);
-		return res.data as PromTemplateSummary;
-	},
-	listTemplates: async (page = 1, pageSize = 20) => {
-		const res = await apiClient.get('/api/v1/proms/templates', { params: { page, pageSize } });
-		return res.data as PromTemplateSummary[];
-	},
-	schedule: async (payload: SchedulePromPayload) => {
-		const res = await apiClient.post('/api/v1/proms/schedule', payload);
-		return res.data;
-	},
-	submitAnswers: async (instanceId: string, answers: Record<string, unknown>) => {
-		const res = await apiClient.post(`/api/v1/proms/instances/${instanceId}/answers`, answers);
-		return res.data as { score: number; completedAt: string };
-	},
-	getInstance: async (id: string) => {
-		const res = await apiClient.get(`/api/v1/proms/instances/${id}`);
-		return res.data;
-	},
+        createTemplate: async (payload: CreatePromTemplateRequest) => {
+                const res = await apiClient.post('/api/v1/proms/templates', payload);
+                return res.data as PromTemplateDetail;
+        },
+        getTemplate: async (key: string, version?: number) => {
+                const path = version ? `/api/v1/proms/templates/${key}/${version}` : `/api/v1/proms/templates/${key}`;
+                const res = await apiClient.get(path);
+                return res.data as PromTemplateDetail;
+        },
+        listTemplates: async (page = 1, pageSize = 20) => {
+                const res = await apiClient.get('/api/v1/proms/templates', { params: { page, pageSize } });
+                return res.data as PromTemplateSummary[];
+        },
+        schedule: async (payload: SchedulePromPayload) => {
+                const res = await apiClient.post('/api/v1/proms/schedule', payload);
+                return res.data;
+        },
+        submitAnswers: async (instanceId: string, answers: Record<string, unknown>) => {
+                const res = await apiClient.post(`/api/v1/proms/instances/${instanceId}/answers`, answers);
+                return res.data as { score: number; completedAt: string };
+        },
+        getInstance: async (id: string) => {
+                const res = await apiClient.get(`/api/v1/proms/instances/${id}`);
+                return res.data;
+        },
 };

--- a/apps/patient-portal/src/pages/CompletePROM.tsx
+++ b/apps/patient-portal/src/pages/CompletePROM.tsx
@@ -154,11 +154,11 @@ export const CompletePROM = () => {
     
     try {
       setSubmitting(true);
-      
-      await api.post(`/api/v1/proms/instances/${id}/answers`, { responses });
-      
+
+      await api.post(`/api/v1/proms/instances/${id}/answers`, responses);
+
       setSuccess(true);
-      
+
       // Redirect after 2 seconds
       setTimeout(() => {
         navigate('/proms');

--- a/backend/Qivr.Services/PromService.cs
+++ b/backend/Qivr.Services/PromService.cs
@@ -1,6 +1,11 @@
 using Microsoft.EntityFrameworkCore;
-using Qivr.Infrastructure.Data;
 using Microsoft.Extensions.Logging;
+using Qivr.Core.Entities;
+using Qivr.Infrastructure.Data;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
 
 namespace Qivr.Services;
 
@@ -23,87 +28,426 @@ public class PromService : IPromService
 		_logger = logger;
 	}
 
-	public async Task<PromTemplateDto> CreateOrVersionTemplateAsync(Guid tenantId, CreatePromTemplateDto request, CancellationToken ct = default)
-	{
-		// Determine next version if existing
-		var version = request.Version;
-		if (version == null)
-		{
-			version = await _db.Database.SqlQuery<int>($@"
-				SELECT COALESCE(MAX(version), 0) + 1 FROM qivr.prom_templates WHERE tenant_id = {tenantId} AND key = {request.Key}")
-				.FirstAsync(ct);
-		}
+        public async Task<PromTemplateDto> CreateOrVersionTemplateAsync(Guid tenantId, CreatePromTemplateDto request, CancellationToken ct = default)
+        {
+                if (string.IsNullOrWhiteSpace(request.Key))
+                {
+                        throw new ArgumentException("Key is required", nameof(request));
+                }
 
-		var id = Guid.NewGuid();
-		var now = DateTime.UtcNow;
+                if (string.IsNullOrWhiteSpace(request.Name))
+                {
+                        throw new ArgumentException("Name is required", nameof(request));
+                }
 
-		await _db.Database.ExecuteSqlInterpolatedAsync($@"
-			INSERT INTO qivr.prom_templates (
-				id, tenant_id, key, version, name, description, questions, scoring_method, scoring_rules, is_active, created_at, updated_at
-			) VALUES (
-				{id}, {tenantId}, {request.Key}, {version}, {request.Name}, {request.Description}, {request.SchemaJson}::jsonb, {request.ScoringMethod}, {request.ScoringRules}::jsonb, {request.IsActive}, {now}, {now}
-			)", ct);
+                if (string.IsNullOrWhiteSpace(request.Category))
+                {
+                        throw new ArgumentException("Category is required", nameof(request));
+                }
 
-		return new PromTemplateDto
-		{
-			Id = id,
-			Key = request.Key,
-			Version = version!.Value,
-			Name = request.Name,
-			Description = request.Description,
-			CreatedAt = now
-		};
-	}
+                if (string.IsNullOrWhiteSpace(request.Frequency))
+                {
+                        throw new ArgumentException("Frequency is required", nameof(request));
+                }
 
-	public async Task<PromTemplateDto?> GetTemplateAsync(Guid tenantId, string key, int? version, CancellationToken ct = default)
-	{
-		if (version.HasValue)
-		{
-			var result = await _db.Database.SqlQuery<PromTemplateDto>($@"
-				SELECT id, key, version, name, description, created_at
-				FROM qivr.prom_templates
-				WHERE tenant_id = {tenantId} AND key = {key} AND version = {version.Value}
-				ORDER BY version DESC
-				LIMIT 1").FirstOrDefaultAsync(ct);
-			return result;
-		}
-		else
-		{
-			var result = await _db.Database.SqlQuery<PromTemplateDto>($@"
-				SELECT id, key, version, name, description, created_at
-				FROM qivr.prom_templates
-				WHERE tenant_id = {tenantId} AND key = {key}
-				ORDER BY version DESC
-				LIMIT 1").FirstOrDefaultAsync(ct);
-			return result;
-		}
-	}
+                if (request.Questions == null || request.Questions.Count == 0)
+                {
+                        throw new ArgumentException("At least one question is required", nameof(request));
+                }
 
-	public async Task<IReadOnlyList<PromTemplateSummaryDto>> ListTemplatesAsync(Guid tenantId, int page, int pageSize, CancellationToken ct = default)
-	{
-		var offset = Math.Max(0, (page - 1) * pageSize);
-		var list = await _db.Database.SqlQuery<PromTemplateSummaryDto>($@"
-			SELECT id, key, version, name, description, created_at
-			FROM qivr.prom_templates
-			WHERE tenant_id = {tenantId}
-			ORDER BY key, version DESC
-			LIMIT {pageSize} OFFSET {offset}").ToListAsync(ct);
-		return list;
-	}
+                var version = request.Version;
+                if (!version.HasValue)
+                {
+                        var latestVersion = await _db.PromTemplates
+                                .Where(t => t.TenantId == tenantId && t.Key == request.Key)
+                                .Select(t => (int?)t.Version)
+                                .OrderByDescending(v => v)
+                                .FirstOrDefaultAsync(ct);
 
-	public async Task<PromTemplateDto?> GetTemplateByIdAsync(Guid tenantId, Guid templateId, CancellationToken ct = default)
-	{
-		var result = await _db.Database.SqlQuery<PromTemplateDto>($@"SELECT id, key, version, name, description, created_at
-			FROM qivr.prom_templates WHERE tenant_id = {tenantId} AND id = {templateId} LIMIT 1").FirstOrDefaultAsync(ct);
-		return result;
-	}
+                        version = (latestVersion ?? 0) + 1;
+                }
+
+                var now = DateTime.UtcNow;
+                var questions = SanitizeQuestionsForStorage(request.Questions);
+                var scoringMethod = request.ScoringMethod != null && request.ScoringMethod.Count > 0
+                        ? NormalizeDictionary(request.ScoringMethod)
+                        : null;
+
+                if (scoringMethod != null && scoringMethod.TryGetValue("type", out var methodValue))
+                {
+                        var method = methodValue?.ToString();
+                        if (!string.IsNullOrWhiteSpace(method))
+                        {
+                                scoringMethod["type"] = method!.Trim().ToLowerInvariant();
+                        }
+                }
+
+                var scoringRules = request.ScoringRules != null && request.ScoringRules.Count > 0
+                        ? NormalizeDictionary(request.ScoringRules)
+                        : null;
+
+                var template = new PromTemplate
+                {
+                        Id = Guid.NewGuid(),
+                        TenantId = tenantId,
+                        Key = request.Key,
+                        Version = version.Value,
+                        Name = request.Name,
+                        Description = request.Description,
+                        Category = request.Category,
+                        Frequency = request.Frequency,
+                        Questions = questions,
+                        ScoringMethod = scoringMethod != null && scoringMethod.Count > 0 ? scoringMethod : null,
+                        ScoringRules = scoringRules != null && scoringRules.Count > 0 ? scoringRules : null,
+                        IsActive = request.IsActive,
+                        CreatedAt = now,
+                        UpdatedAt = now
+                };
+
+                await _db.PromTemplates.AddAsync(template, ct);
+                await _db.SaveChangesAsync(ct);
+
+                return MapToDto(template);
+        }
+
+        public async Task<PromTemplateDto?> GetTemplateAsync(Guid tenantId, string key, int? version, CancellationToken ct = default)
+        {
+                var query = _db.PromTemplates
+                        .AsNoTracking()
+                        .Where(t => t.TenantId == tenantId && t.Key == key);
+
+                if (version.HasValue)
+                {
+                        query = query.Where(t => t.Version == version.Value);
+                }
+
+                var template = await query
+                        .OrderByDescending(t => t.Version)
+                        .FirstOrDefaultAsync(ct);
+
+                return template == null ? null : MapToDto(template);
+        }
+
+        public async Task<IReadOnlyList<PromTemplateSummaryDto>> ListTemplatesAsync(Guid tenantId, int page, int pageSize, CancellationToken ct = default)
+        {
+                var offset = Math.Max(0, (page - 1) * pageSize);
+
+                var list = await _db.PromTemplates
+                        .AsNoTracking()
+                        .Where(t => t.TenantId == tenantId)
+                        .OrderBy(t => t.Key)
+                        .ThenByDescending(t => t.Version)
+                        .Skip(offset)
+                        .Take(pageSize)
+                        .Select(t => new PromTemplateSummaryDto
+                        {
+                                Id = t.Id,
+                                Key = t.Key,
+                                Version = t.Version,
+                                Name = t.Name,
+                                Description = t.Description,
+                                Category = t.Category,
+                                Frequency = t.Frequency,
+                                IsActive = t.IsActive,
+                                CreatedAt = t.CreatedAt,
+                                UpdatedAt = t.UpdatedAt
+                        })
+                        .ToListAsync(ct);
+
+                return list;
+        }
+
+        public async Task<PromTemplateDto?> GetTemplateByIdAsync(Guid tenantId, Guid templateId, CancellationToken ct = default)
+        {
+                var template = await _db.PromTemplates
+                        .AsNoTracking()
+                        .FirstOrDefaultAsync(t => t.TenantId == tenantId && t.Id == templateId, ct);
+
+                return template == null ? null : MapToDto(template);
+        }
 
 
-	private static decimal CalculateScore(string? method, string? rulesJson, Dictionary<string, object> answers)
-	{
-		if (string.IsNullOrWhiteSpace(method)) return 0m;
-		switch (method.ToLowerInvariant())
-		{
+        private static PromTemplateDto MapToDto(PromTemplate template)
+        {
+                return new PromTemplateDto
+                {
+                        Id = template.Id,
+                        Key = template.Key,
+                        Version = template.Version,
+                        Name = template.Name,
+                        Description = template.Description,
+                        Category = template.Category,
+                        Frequency = template.Frequency,
+                        Questions = CloneQuestions(template.Questions),
+                        ScoringMethod = CloneDictionary(template.ScoringMethod),
+                        ScoringRules = CloneDictionary(template.ScoringRules),
+                        IsActive = template.IsActive,
+                        CreatedAt = template.CreatedAt,
+                        UpdatedAt = template.UpdatedAt
+                };
+        }
+
+        private static List<Dictionary<string, object>> SanitizeQuestionsForStorage(IEnumerable<Dictionary<string, object>> questions)
+        {
+                var sanitized = new List<Dictionary<string, object>>();
+                var index = 0;
+
+                foreach (var question in questions)
+                {
+                        if (question == null)
+                        {
+                                continue;
+                        }
+
+                        var normalized = NormalizeDictionary(question);
+
+                        normalized["id"] = ExtractQuestionId(normalized);
+                        normalized["order"] = index;
+                        normalized["type"] = NormalizeQuestionType(normalized);
+                        var text = NormalizeQuestionText(normalized);
+                        normalized["text"] = text;
+                        normalized["question"] = text;
+                        normalized["required"] = normalized.TryGetValue("required", out var requiredValue)
+                                ? NormalizeBoolean(requiredValue)
+                                : false;
+
+                        if (normalized.TryGetValue("options", out var optionsValue))
+                        {
+                                normalized["options"] = NormalizeValue(optionsValue) ?? new List<object?>();
+                        }
+
+                        sanitized.Add(normalized);
+                        index++;
+                }
+
+                return sanitized;
+        }
+
+        private static List<Dictionary<string, object>> CloneQuestions(IReadOnlyCollection<Dictionary<string, object>>? source)
+        {
+                if (source == null || source.Count == 0)
+                {
+                        return new List<Dictionary<string, object>>();
+                }
+
+                var cloned = new List<Dictionary<string, object>>(source.Count);
+                foreach (var question in source)
+                {
+                        cloned.Add(NormalizeDictionary(question));
+                }
+
+                return cloned;
+        }
+
+        private static Dictionary<string, object>? CloneDictionary(Dictionary<string, object>? source)
+        {
+                if (source == null || source.Count == 0)
+                {
+                        return null;
+                }
+
+                return NormalizeDictionary(source);
+        }
+
+        private static Dictionary<string, object> NormalizeDictionary(Dictionary<string, object> source)
+        {
+                return NormalizeDictionary((IDictionary)source);
+        }
+
+        private static Dictionary<string, object> NormalizeDictionary(IDictionary source)
+        {
+                var normalized = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (DictionaryEntry entry in source)
+                {
+                        if (entry.Key is not string key || string.IsNullOrWhiteSpace(key))
+                        {
+                                continue;
+                        }
+
+                        var value = NormalizeValue(entry.Value);
+                        normalized[key] = value ?? null!;
+                }
+
+                return normalized;
+        }
+
+        private static object? NormalizeValue(object? value)
+        {
+                if (value == null)
+                {
+                        return null;
+                }
+
+                if (value is JsonElement element)
+                {
+                        return NormalizeJsonElement(element);
+                }
+
+                if (value is IDictionary dictionary)
+                {
+                        return NormalizeDictionary(dictionary);
+                }
+
+                if (value is IEnumerable enumerable && value is not string)
+                {
+                        var list = new List<object?>();
+                        foreach (var item in enumerable)
+                        {
+                                list.Add(NormalizeValue(item));
+                        }
+
+                        return list;
+                }
+
+                return value;
+        }
+
+        private static object? NormalizeJsonElement(JsonElement element)
+        {
+                switch (element.ValueKind)
+                {
+                        case JsonValueKind.String:
+                                return element.GetString();
+                        case JsonValueKind.Number:
+                                if (element.TryGetInt64(out var longValue))
+                                {
+                                        return longValue;
+                                }
+
+                                if (element.TryGetDecimal(out var decimalValue))
+                                {
+                                        return decimalValue;
+                                }
+
+                                return element.GetDouble();
+                        case JsonValueKind.True:
+                                return true;
+                        case JsonValueKind.False:
+                                return false;
+                        case JsonValueKind.Null:
+                        case JsonValueKind.Undefined:
+                                return null;
+                        case JsonValueKind.Object:
+                                var dict = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+                                foreach (var property in element.EnumerateObject())
+                                {
+                                        dict[property.Name] = NormalizeJsonElement(property.Value) ?? null!;
+                                }
+
+                                return dict;
+                        case JsonValueKind.Array:
+                                var list = new List<object?>();
+                                foreach (var item in element.EnumerateArray())
+                                {
+                                        list.Add(NormalizeJsonElement(item));
+                                }
+
+                                return list;
+                        default:
+                                return element.GetRawText();
+                }
+        }
+
+        private static string ExtractQuestionId(Dictionary<string, object> question)
+        {
+                if (question.TryGetValue("id", out var idValue) && Guid.TryParse(idValue?.ToString(), out var parsed))
+                {
+                        return parsed.ToString();
+                }
+
+                return Guid.NewGuid().ToString();
+        }
+
+        private static string NormalizeQuestionType(Dictionary<string, object> question)
+        {
+                if (question.TryGetValue("type", out var typeValue))
+                {
+                        var typeString = typeValue?.ToString();
+                        if (!string.IsNullOrWhiteSpace(typeString))
+                        {
+                                return typeString.Trim().ToLowerInvariant();
+                        }
+                }
+
+                return "text";
+        }
+
+        private static string NormalizeQuestionText(Dictionary<string, object> question)
+        {
+                if (question.TryGetValue("text", out var textValue))
+                {
+                        var text = textValue?.ToString()?.Trim();
+                        if (!string.IsNullOrWhiteSpace(text))
+                        {
+                                return text!;
+                        }
+                }
+
+                if (question.TryGetValue("question", out var questionValue))
+                {
+                        var text = questionValue?.ToString()?.Trim();
+                        if (!string.IsNullOrWhiteSpace(text))
+                        {
+                                return text!;
+                        }
+                }
+
+                return string.Empty;
+        }
+
+        private static bool NormalizeBoolean(object? value)
+        {
+                if (value == null)
+                {
+                        return false;
+                }
+
+                if (value is bool boolean)
+                {
+                        return boolean;
+                }
+
+                if (value is JsonElement element)
+                {
+                        return element.ValueKind switch
+                        {
+                                JsonValueKind.True => true,
+                                JsonValueKind.False => false,
+                                JsonValueKind.Number when element.TryGetInt32(out var numeric) => numeric != 0,
+                                JsonValueKind.String when bool.TryParse(element.GetString(), out var parsed) => parsed,
+                                _ => false
+                        };
+                }
+
+                if (value is string text && bool.TryParse(text, out var parsedBool))
+                {
+                        return parsedBool;
+                }
+
+                if (value is sbyte or byte or short or ushort or int or uint or long or ulong)
+                {
+                        return Convert.ToInt64(value) != 0;
+                }
+
+                if (value is decimal decimalValue)
+                {
+                        return decimalValue != 0m;
+                }
+
+                if (value is double doubleValue)
+                {
+                        return Math.Abs(doubleValue) > double.Epsilon;
+                }
+
+                return false;
+        }
+
+        private static decimal CalculateScore(string? method, string? rulesJson, Dictionary<string, object> answers)
+        {
+                if (string.IsNullOrWhiteSpace(method)) return 0m;
+                switch (method.ToLowerInvariant())
+                {
 			case "sum":
 				return answers.Values
 					.Where(v => decimal.TryParse(v?.ToString(), System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out _))
@@ -124,34 +468,47 @@ public class PromService : IPromService
 // DTOs for service layer
 public sealed class CreatePromTemplateDto
 {
-	public string Key { get; set; } = string.Empty;
-	public string Name { get; set; } = string.Empty;
-	public string? Description { get; set; }
-	public string SchemaJson { get; set; } = "{}"; // JSON string
-	public string? ScoringMethod { get; set; }
-	public string? ScoringRules { get; set; } // JSON string
-	public bool IsActive { get; set; } = true;
-	public int? Version { get; set; }
+        public string Key { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string? Description { get; set; }
+        public string Category { get; set; } = string.Empty;
+        public string Frequency { get; set; } = string.Empty;
+        public List<Dictionary<string, object>> Questions { get; set; } = new();
+        public Dictionary<string, object>? ScoringMethod { get; set; }
+        public Dictionary<string, object>? ScoringRules { get; set; }
+        public bool IsActive { get; set; } = true;
+        public int? Version { get; set; }
 }
 
 public sealed class PromTemplateDto
 {
-	public Guid Id { get; set; }
-	public string Key { get; set; } = string.Empty;
-	public int Version { get; set; }
-	public string Name { get; set; } = string.Empty;
-	public string? Description { get; set; }
-	public DateTime CreatedAt { get; set; }
+        public Guid Id { get; set; }
+        public string Key { get; set; } = string.Empty;
+        public int Version { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string? Description { get; set; }
+        public string Category { get; set; } = string.Empty;
+        public string Frequency { get; set; } = string.Empty;
+        public List<Dictionary<string, object>> Questions { get; set; } = new();
+        public Dictionary<string, object>? ScoringMethod { get; set; }
+        public Dictionary<string, object>? ScoringRules { get; set; }
+        public bool IsActive { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
 }
 
 public sealed class PromTemplateSummaryDto
 {
-	public Guid Id { get; set; }
-	public string Key { get; set; } = string.Empty;
-	public int Version { get; set; }
-	public string Name { get; set; } = string.Empty;
-	public string? Description { get; set; }
-	public DateTime CreatedAt { get; set; }
+        public Guid Id { get; set; }
+        public string Key { get; set; } = string.Empty;
+        public int Version { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string? Description { get; set; }
+        public string Category { get; set; } = string.Empty;
+        public string Frequency { get; set; } = string.Empty;
+        public bool IsActive { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime UpdatedAt { get; set; }
 }
 
 public sealed class SchedulePromRequest

--- a/backend/Qivr.Tests/Controllers/PromsControllerTests.cs
+++ b/backend/Qivr.Tests/Controllers/PromsControllerTests.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Qivr.Api.Controllers;
+using Qivr.Infrastructure.Data;
+using Qivr.Services;
+using Xunit;
+
+namespace Qivr.Tests.Controllers;
+
+public class PromsControllerTests
+{
+    [Fact]
+    public async Task CreateTemplate_PersistsStructuredFields()
+    {
+        var tenantId = Guid.NewGuid();
+        var options = new DbContextOptionsBuilder<QivrDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        await using var context = new QivrDbContext(options);
+        var promService = new PromService(context, NullLogger<PromService>.Instance);
+        var promInstanceService = new Mock<IPromInstanceService>();
+
+        var controller = new PromsController(promService, promInstanceService.Object, NullLogger<PromsController>.Instance)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                    {
+                        new Claim("tenant_id", tenantId.ToString()),
+                        new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()),
+                        new Claim(ClaimTypes.Role, "Admin")
+                    }, "Test"))
+                }
+            }
+        };
+
+        var request = new CreatePromTemplateDto
+        {
+            Key = "phq-9",
+            Name = "PHQ-9",
+            Description = "Depression screener",
+            Category = "Mental Health",
+            Frequency = "Weekly",
+            Questions = new List<Dictionary<string, object>>
+            {
+                new()
+                {
+                    ["id"] = "q1",
+                    ["text"] = "Little interest or pleasure in doing things",
+                    ["type"] = "scale",
+                    ["required"] = true,
+                    ["options"] = new[] { 0, 1, 2, 3 }
+                }
+            },
+            ScoringMethod = new Dictionary<string, object>
+            {
+                ["type"] = "sum"
+            },
+            ScoringRules = new Dictionary<string, object>
+            {
+                ["low"] = 0,
+                ["moderate"] = 10,
+                ["high"] = 20
+            }
+        };
+
+        var response = await controller.CreateOrVersionTemplate(request, CancellationToken.None);
+
+        var created = Assert.IsType<CreatedAtActionResult>(response.Result);
+        var dto = Assert.IsType<PromTemplateDto>(created.Value);
+        Assert.Equal(request.Category, dto.Category);
+        Assert.Equal(request.Frequency, dto.Frequency);
+        Assert.Single(dto.Questions);
+        var dtoQuestion = Assert.Single(dto.Questions);
+        Assert.True(Guid.TryParse(dtoQuestion["id"].ToString(), out _));
+        Assert.Equal(0, Convert.ToInt32(dtoQuestion["order"]));
+        Assert.True(dtoQuestion.TryGetValue("required", out var requiredValue) && requiredValue is bool required && required);
+        Assert.Equal("sum", dto.ScoringMethod?["type"]?.ToString());
+        Assert.NotEqual(default, dto.CreatedAt);
+        Assert.NotEqual(default, dto.UpdatedAt);
+
+        var stored = await context.PromTemplates.AsNoTracking().SingleAsync();
+        Assert.Equal(request.Category, stored.Category);
+        Assert.Equal(request.Frequency, stored.Frequency);
+        var storedQuestion = Assert.Single(stored.Questions);
+        Assert.True(Guid.TryParse(storedQuestion["id"].ToString(), out _));
+        Assert.Equal("scale", storedQuestion["type"].ToString());
+        Assert.Equal("Little interest or pleasure in doing things", storedQuestion["text"].ToString());
+        Assert.Equal("sum", stored.ScoringMethod?["type"]?.ToString());
+
+        await using var verificationContext = new QivrDbContext(options);
+        var verificationService = new PromService(verificationContext, NullLogger<PromService>.Instance);
+        var reloaded = await verificationService.GetTemplateAsync(tenantId, request.Key, dto.Version, CancellationToken.None);
+        Assert.NotNull(reloaded);
+        var reloadedQuestion = Assert.Single(reloaded!.Questions);
+        Assert.True(Guid.TryParse(reloadedQuestion["id"].ToString(), out _));
+        Assert.Equal(dtoQuestion["id"].ToString(), reloadedQuestion["id"].ToString());
+        Assert.Equal("sum", reloaded.ScoringMethod?["type"]?.ToString());
+        Assert.Equal(dto.Id, reloaded.Id);
+    }
+
+    [Fact]
+    public async Task ListTemplates_ReturnsSummaryMetadata()
+    {
+        var tenantId = Guid.NewGuid();
+        var options = new DbContextOptionsBuilder<QivrDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        var templateRequest = new CreatePromTemplateDto
+        {
+            Key = "gad-7",
+            Name = "GAD-7",
+            Category = "Mental Health",
+            Frequency = "Monthly",
+            Questions = new List<Dictionary<string, object>>
+            {
+                new()
+                {
+                    ["text"] = "Feeling nervous, anxious, or on edge",
+                    ["type"] = "scale",
+                    ["required"] = true
+                }
+            }
+        };
+
+        await using (var context = new QivrDbContext(options))
+        {
+            var service = new PromService(context, NullLogger<PromService>.Instance);
+            await service.CreateOrVersionTemplateAsync(tenantId, templateRequest, CancellationToken.None);
+        }
+
+        await using var verificationContext = new QivrDbContext(options);
+        var verificationService = new PromService(verificationContext, NullLogger<PromService>.Instance);
+        var summaries = await verificationService.ListTemplatesAsync(tenantId, 1, 10, CancellationToken.None);
+
+        var summary = Assert.Single(summaries);
+        Assert.Equal(templateRequest.Key, summary.Key);
+        Assert.Equal(templateRequest.Category, summary.Category);
+        Assert.Equal(templateRequest.Frequency, summary.Frequency);
+        Assert.True(summary.IsActive);
+        Assert.NotEqual(default, summary.CreatedAt);
+        Assert.NotEqual(default, summary.UpdatedAt);
+    }
+}

--- a/backend/Qivr.Tests/Services/PromInstanceServiceTests.cs
+++ b/backend/Qivr.Tests/Services/PromInstanceServiceTests.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Qivr.Core.Entities;
+using Qivr.Infrastructure.Data;
+using Qivr.Services;
+using Xunit;
+
+namespace Qivr.Tests.Services;
+
+public class PromInstanceServiceTests
+{
+    [Fact]
+    public async Task SubmitPromResponse_AppliesWeightedScoringAndSeverityRanges()
+    {
+        var tenantId = Guid.NewGuid();
+        var question1Id = Guid.NewGuid();
+        var question2Id = Guid.NewGuid();
+
+        var options = new DbContextOptionsBuilder<QivrDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        await using var context = new QivrDbContext(options);
+        var promService = new PromService(context, NullLogger<PromService>.Instance);
+
+        var templateDto = await promService.CreateOrVersionTemplateAsync(
+            tenantId,
+            new CreatePromTemplateDto
+            {
+                Key = "weighted-test",
+                Name = "Weighted Test",
+                Category = "Test",
+                Frequency = "Monthly",
+                Questions = new List<Dictionary<string, object>>
+                {
+                    new()
+                    {
+                        ["id"] = question1Id.ToString(),
+                        ["text"] = "Pain level",
+                        ["type"] = "scale",
+                        ["required"] = true
+                    },
+                    new()
+                    {
+                        ["id"] = question2Id.ToString(),
+                        ["text"] = "Mobility",
+                        ["type"] = "scale",
+                        ["required"] = true
+                    }
+                },
+                ScoringMethod = new Dictionary<string, object>
+                {
+                    ["type"] = "weighted"
+                },
+                ScoringRules = new Dictionary<string, object>
+                {
+                    ["questions"] = new List<Dictionary<string, object>>
+                    {
+                        new()
+                        {
+                            ["id"] = question1Id.ToString(),
+                            ["weight"] = 2
+                        },
+                        new()
+                        {
+                            ["id"] = question2Id.ToString(),
+                            ["weight"] = 1
+                        }
+                    },
+                    ["ranges"] = new List<Dictionary<string, object>>
+                    {
+                        new()
+                        {
+                            ["min"] = 0,
+                            ["max"] = 1.9m,
+                            ["label"] = "low"
+                        },
+                        new()
+                        {
+                            ["min"] = 2m,
+                            ["max"] = 3.5m,
+                            ["label"] = "medium"
+                        },
+                        new()
+                        {
+                            ["min"] = 3.6m,
+                            ["label"] = "high"
+                        }
+                    }
+                }
+            },
+            CancellationToken.None);
+
+        var storedQuestion1Id = Guid.Parse(templateDto.Questions[0]["id"].ToString()!);
+        var storedQuestion2Id = Guid.Parse(templateDto.Questions[1]["id"].ToString()!);
+
+        var patient = new User
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            CognitoSub = Guid.NewGuid().ToString(),
+            Email = "patient@example.com",
+            UserType = UserType.Patient,
+            FirstName = "Patient",
+            LastName = "One"
+        };
+
+        context.Users.Add(patient);
+
+        var templateEntity = await context.PromTemplates.SingleAsync();
+        var instance = new PromInstance
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            TemplateId = templateEntity.Id,
+            Template = templateEntity,
+            PatientId = patient.Id,
+            Patient = patient,
+            ScheduledFor = DateTime.UtcNow,
+            DueDate = DateTime.UtcNow.AddDays(7)
+        };
+
+        context.PromInstances.Add(instance);
+        await context.SaveChangesAsync();
+
+        var notificationService = new Mock<INotificationService>();
+        var service = new PromInstanceService(context, notificationService.Object, NullLogger<PromInstanceService>.Instance);
+
+        var request = new PromSubmissionRequest
+        {
+            SubmittedAt = DateTime.UtcNow,
+            Answers = new List<PromAnswer>
+            {
+                new() { QuestionId = storedQuestion1Id, Value = 3 },
+                new() { QuestionId = storedQuestion2Id, Value = 2 }
+            }
+        };
+
+        var dto = await service.SubmitPromResponseAsync(tenantId, instance.Id, request, CancellationToken.None);
+
+        Assert.NotNull(dto);
+        Assert.True(dto.TotalScore.HasValue);
+        Assert.Equal(8m / 3m, dto.TotalScore!.Value);
+
+        var storedInstance = await context.PromInstances.FindAsync(instance.Id);
+        Assert.Equal(8m / 3m, storedInstance!.Score);
+
+        var storedResponse = await context.PromResponses.SingleAsync();
+        Assert.Equal("medium", storedResponse.Severity);
+    }
+}

--- a/docs/proms-integration-plan.md
+++ b/docs/proms-integration-plan.md
@@ -1,0 +1,23 @@
+# PROM Integration Audit and Remediation Plan
+
+## Audit Summary
+- The backend `PromTemplate` entity now persists structured `Questions`, `ScoringMethod`, `ScoringRules`, and requires `Category` and `Frequency`, but the clinic dashboard still posts legacy fields (`schemaJson`, string `scoringMethod`/`scoringRules`) so template creation fails to satisfy the schema and does not store usable JSON.
+- Clinic dashboard experiences expect template listings to include full question definitions even though `/api/v1/proms/templates` now returns summary data, and the PROM builder still generates non-GUID question identifiers that the backend discards during scoring.
+- Patient portal submissions wrap responses inside a `responses` object; the API expects a raw dictionary keyed by question GUID, so answers are stored against an empty GUID and ignored when calculating scores.
+
+## Remediation Objectives
+1. Align clinic dashboard API clients and builder payloads with the new backend DTOs so created templates include category, frequency, structured questions, and scoring metadata.
+2. Ensure clinic dashboard experiences resolve full template details as needed (preview, sender wizard) while respecting the summary response returned by the listing endpoint.
+3. Guarantee PROM question identifiers are stable GUIDs from creation through submission to support backend scoring rules.
+4. Update patient portal submission flows to post the raw answer dictionary the API expects so responses persist correctly.
+
+## Implementation Plan
+- Extend the PROM builder UI to capture a required frequency value, emit GUID-based question IDs, and transform builder state into the structured payload (`questions`, `scoringMethod`, `scoringRules`) required by `CreatePromTemplateDto`.
+- Refactor `promApi`/`proms` services so `createTemplate` sends the new payload shape, listings expose summary metadata, and detailed fetches hydrate full question/scoring data for consumers.
+- Update the PROM sender workflow to fetch detail on demand for the selected template, relying on summaries for discovery but using the detailed DTO for preview, counts, and scheduling metadata.
+- Adjust patient portal completion to submit the answer dictionary directly (without the `responses` wrapper) so the backend can map answers back to question GUIDs.
+
+## Expected Outcomes
+- Clinic staff can create PROM templates that persist all required metadata without violating database constraints.
+- Template previews and sending workflows display complete question sets by resolving detailed templates on demand.
+- Patient responses are stored with the correct question identifiers, allowing scoring and reporting to operate end-to-end.


### PR DESCRIPTION
## Summary
- enforce PROM template key/name/question validation and normalize question/scoring payloads before persistence
- expose category, frequency, activity state, and updated timestamps through template DTOs for dashboard consumption
- extend controller tests and clinic dashboard types to cover normalized payloads and enriched summaries

## Testing
- `dotnet test backend/Qivr.Tests/Qivr.Tests.csproj` *(fails: dotnet CLI not available in container)*
- `npm run lint --workspace=@qivr/clinic-dashboard` *(fails: ESLint shared config "react-app" missing in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b9e01784832db931ac896d064a98